### PR TITLE
Add delta support

### DIFF
--- a/docker/spark_conda/Dockerfile.spark
+++ b/docker/spark_conda/Dockerfile.spark
@@ -29,7 +29,9 @@ RUN mkdir /workspace \
     && chmod 755 /usr/local/bin/start-spark-worker.sh \
     && chmod 755 /usr/local/bin/start-spark-driver.sh \
     && wget https://github.com/microsoft/mssql-jdbc/releases/download/v7.2.2/mssql-jdbc-7.2.2.jre8.jar \
-    && cp mssql-jdbc-7.2.2.jre8.jar spark/jars \
+    && wget https://repo1.maven.org/maven2/io/delta/delta-core_2.12/1.2.1/delta-core_2.12-1.2.1.jar \
+    && wget https://repo1.maven.org/maven2/io/delta/delta-storage/1.2.1/delta-storage-1.2.1.jar \
+    && mv *.jar spark/jars \
     && mkdir /shared_data
 
 COPY shared/templates/hive-site.xml /spark/conf/hive-site.xml


### PR DESCRIPTION
Put the delta-core and delta-storage jar files into the spark installation to give delta support without having to explicitly configure for delta either by the configure_spark_with_delta_pip api call when having installed the delta-spark pypi package or by starting a pyspark shell with the delta package specification