### PR TITLE
Spark update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ in .NET. Both setups include support for Delta Lake.
 The reason for the different setups using different spark version is simply that the highest version of Spark currently supported by Spark DotNet is 3.2.1
 
 #### Shared
-* Hive metastore 3.1.2 (Hadoop 3.3.2)
+* Hive metastore 3.1.3 (Hadoop 3.3.4)
 * Postgres 15.1
 * Minio latest version (Dockerfile will pull latest minio image)
 * Apache Superset 2.0.1
 #### Python (Conda)
-* Spark 3.3.1 (Hadoop 3.3.2)
-* Delta lake 2.1.1
+* Spark 3.4.1 (Hadoop 3.3.4)
+* Delta lake 2.4.0
 * Conda (Dockerfile downloads and installs latest conda version)
 #### Dotnet
 * Spark 3.2.1 (Hadoop 3.3.1) 
@@ -29,8 +29,7 @@ The reason for the different setups using different spark version is simply that
 #### GPU
 * CUDA 11.4.0 (Can be changed to a different version in the build.sh file)
 
-**_NOTE:_** When installing Spark 3.2.1 with Hadoop 3.x pre compiled the file name in the archive says hadoop3.2. The actual spark installation actually comes with
-Hadoop 3.3.1 pre-compiled, and not 3.2.x. 
+**_NOTE:_** When installing Spark 3.4.1 with Hadoop 3.x pre compiled the file name in the archive says hadoop3. Since it is needed in certain places, I will mention here that it comes with Hadoop 3.3.4 pre-compiled
 
 ## Spark with conda container
 This container comes with latest linux version of conda pre-installed and initalized in the bash shell.

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -7,7 +7,7 @@ set -o errexit # abort on nonzero exit status
 set -o nounset # abort on unbound variable
 set -o pipefail # dont hide errors within pipes
 
-readonly conda_apache_spark_version=3.3.1
+readonly conda_apache_spark_version=3.4.1
 readonly dotnet_apache_spark_version=3.2.1
 readonly conda_hadoop_short_version=3
 readonly dotnet_hadoop_short_version=3.2

--- a/docker/docker-compose.shared.yml
+++ b/docker/docker-compose.shared.yml
@@ -51,7 +51,7 @@ services:
       args:
         - HIVE_USER_PASSWORD=Supersecretpassw0rd!
     entrypoint: /scripts/init-hive.sh
-    image: hive:3.1.2
+    image: hive:3.1.3
     ports:
       - 10000:10000
       - 9083:9083

--- a/docker/docker-compose.spark-conda.yml
+++ b/docker/docker-compose.spark-conda.yml
@@ -34,7 +34,7 @@ services:
       dockerfile: ./spark_conda/Dockerfile.conda
       args:
         - HIVE_USER_PASSWORD=Supersecretpassw0rd!
-    image: spark-conda:3.3.1
+    image: spark-conda:3.4.1
     ports: 
       - 4040:4040
     hostname: spark

--- a/docker/shared/Dockerfile.hive
+++ b/docker/shared/Dockerfile.hive
@@ -1,8 +1,8 @@
 FROM java-base:8
 
 ARG HIVE_USER_PASSWORD=Supersecretpassw0rd!
-ARG HADOOP_VERSION=3.3.2
-ARG HIVE_VERSION=3.1.2
+ARG HADOOP_VERSION=3.3.4
+ARG HIVE_VERSION=3.1.3
 
 RUN apt-get update \
     && apt-get install -y openssh-server \
@@ -34,7 +34,7 @@ RUN wget https://repo1.maven.org/maven2/org/apache/hive/hive-standalone-metastor
     && wget https://jdbc.postgresql.org/download/postgresql-42.5.1.jar \
     # # JAR files for Amazon S3 (required for connecting to Minio as warehouse)
     && wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/${HADOOP_VERSION}/hadoop-aws-${HADOOP_VERSION}.jar \
-    && wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.1026/aws-java-sdk-bundle-1.11.1026.jar \
+    && wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar \
     && mv *.jar opt/hive/lib
 
 COPY templates/hive-site.xml /opt/hive/conf/hive-site.xml

--- a/docker/shared/templates/hive-site.xml
+++ b/docker/shared/templates/hive-site.xml
@@ -38,7 +38,7 @@
    </property>
    <property>
       <name>spark.sql.hive.metastore.version</name>
-      <value>3.1.2</value>
+      <value>3.1.3</value>
       <description>Hive version to use.</description>
    </property>
    <property>

--- a/docker/shared/templates/minio-scripts/init-minio.sh
+++ b/docker/shared/templates/minio-scripts/init-minio.sh
@@ -8,7 +8,7 @@ if [ ! -f /scripts/.init-minio-complete ]; then
     mc alias set myminio http://localhost:9000 <ROOTADMIN> <ROOTPASSWORD>
     mc admin user add myminio minio_hive_user <HIVEUSERPASSWORD>
     mc mb myminio/hive
-    mc admin policy set myminio readwrite user=minio_hive_user
+    mc admin policy attach myminio readwrite --user minio_hive_user
 
     # When doing the above in the entrypoint, the docker container exists beliving the server is no longer running (even with nohup).
     # Adding the below to shut the server down and restart it to keep the continer (and minio server) going.

--- a/docker/spark_conda/Dockerfile.conda
+++ b/docker/spark_conda/Dockerfile.conda
@@ -1,4 +1,4 @@
-FROM spark:3.3.1
+FROM spark:3.4.1
 
 ARG HIVE_USER_PASSWORD=Supersecretpassw0rd!
 

--- a/docker/spark_conda/Dockerfile.spark
+++ b/docker/spark_conda/Dockerfile.spark
@@ -1,7 +1,7 @@
 FROM java-base:8
 
-ARG SPARK_VERSION=3.3.1
-ARG HADOOP_VERSION=3.3.2
+ARG SPARK_VERSION=3.4.1
+ARG HADOOP_VERSION=3.3.4
 ARG HADOOP_VERSION_SHORT=3
 ENV DEAMON_RUN=true \
     HADOOP_VERSION=${HADOOP_VERSION} \
@@ -33,13 +33,13 @@ RUN mkdir /workspace \
     # JAR file for jbdc connector to postgres server
     && wget https://jdbc.postgresql.org/download/postgresql-42.5.1.jar \ 
     # JAR files for Delta lake
-    && wget https://repo1.maven.org/maven2/io/delta/delta-core_2.12/2.1.1/delta-core_2.12-2.1.1.jar \
-    && wget https://repo1.maven.org/maven2/io/delta/delta-storage/2.1.1/delta-storage-2.1.1.jar \
+    && wget https://repo1.maven.org/maven2/io/delta/delta-core_2.12/2.4.0/delta-core_2.12-2.4.0.jar \
+    && wget https://repo1.maven.org/maven2/io/delta/delta-storage/2.4.0/delta-storage-2.4.0.jar \
     # JAR files for Amazon S3 (required for connecting to Minio)
     && wget https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/${HADOOP_VERSION}/hadoop-aws-${HADOOP_VERSION}.jar \
-    && wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.11.1026/aws-java-sdk-bundle-1.11.1026.jar \
+    && wget https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar \
     # JAR file for Apache Iceberg
-    && wget https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.3_2.12/1.1.0/iceberg-spark-runtime-3.3_2.12-1.1.0.jar \
+    && wget https://repo1.maven.org/maven2/org/apache/iceberg/iceberg-spark-runtime-3.4_2.12/1.3.0/iceberg-spark-runtime-3.4_2.12-1.3.0.jar \
     && mv *.jar spark/jars \
     && mkdir /shared_data
 

--- a/examples/python/nba_prediction/data_modeling.py
+++ b/examples/python/nba_prediction/data_modeling.py
@@ -4,7 +4,7 @@ from pyspark.sql import SparkSession, DataFrame
 import pyspark.sql.functions as F
 import pyspark.sql.types as T
 
-_path_to_raw = "shared_datasets/"
+_path_to_raw = "../shared_datasets/"
 
 def check_if_nba_tables_exist(spark: SparkSession) -> bool:
     table_names = ["Teams", "TeamSeasonStats", "Players", "PlayerSeasonAwardShare", "PlayerSeasonAdvancedStats",

--- a/examples/python/nba_prediction/how-to.md
+++ b/examples/python/nba_prediction/how-to.md
@@ -4,7 +4,7 @@ This project has only been developed and tested in vscode and the below instruct
 To run and develop this project the the following steps should be executed:
 1. Create a conda environment with the command <b>conda create -n ENV-NAME python=PYTHON-VERSION</b>
 2. Activate the created conda environment with the commdan <b>conda activate ENV-NAME</b>
-3. Install the pyspark package version 3.3.1 from conda-forge into the conda environment using the command <b>conda install -c conda-forge pyspark==3.2.1</b>
+3. Install the pyspark package version 3.4.1 from conda-forge into the conda environment using the command <b>conda install -c conda-forge pyspark==3.4.1</b>
 4. Set the python interpeter used in vscode to the python.exe found in the conda environment folder.
 
 The delta lake jars are added to the spark jars folder as part of building the docker image, which is why the delta-spark package does not need to be installed and why there is also no need for configuring the spark session with configure_spark_with_delta_pip().


### PR DESCRIPTION
 * Update from Spark 3.3.1 to 3.4.1
 * Update from Hive Metastore 3.1.2 to 3.1.3
 * Hadoop from 3.3.2 to 3.3.4
 * Update to later AWS Java SDK bundle for the Minio
 * Update init-minio.sh with policy attach instead of apply (which has been deprecated) for giving the hive user read/write access to hive bucket.